### PR TITLE
VMC over SMB seems to get corrupted by some games. Reverting the shif…

### DIFF
--- a/modules/iopcore/cdvdman/device-smb.c
+++ b/modules/iopcore/cdvdman/device-smb.c
@@ -82,7 +82,8 @@ void DeviceInit(void)
 }
 
 void DeviceDeinit(void)
-{
+{   // Close all files and disconnect before IOP reboots. Note that this seems to help prevent VMC corruption in some games.
+    DeviceUnmount();
 }
 
 void DeviceFSInit(void)


### PR DESCRIPTION
…ting of smb_Disconnect() from DeviceDeinit() to DeviceUnmount() seems to prevent this.

It may be also related to the IOP reboot, since this function is called from the _exit() function, which is called when the module is unloaded (before IOP reboots etc).
Related to commit 8dbaaae2.

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

